### PR TITLE
Fixing the state class to remove action sequences of: ["raise", "call", "call"] when 2 players

### DIFF
--- a/pluribus/games/short_deck/state.py
+++ b/pluribus/games/short_deck/state.py
@@ -44,18 +44,11 @@ class ShortDeckPokerState:
         else:
             self.info_set_lut = {}
         # Get a reference of the pot from the first player.
-        self._table = PokerTable(players=players, pot=players[0].pot)
+        self._table = PokerTable(
+            players=players, pot=players[0].pot, include_ranks=[10, 11, 12, 13, 14]
+        )
         # Get a reference of the initial number of chips for the payout.
         self._initial_n_chips = players[0].n_chips
-        # TODO(fedden): There are an awful lot of layers of abstraction here,
-        #               this could be much neater, maybe refactor and clean
-        #               things up a bit here in the future.
-        # Shorten the deck.
-        self._table.dealer.deck._cards = [
-            card
-            for card in self._table.dealer.deck._cards
-            if card.rank_int not in {2, 3, 4, 5, 6, 7, 8, 9}
-        ]
         self.small_blind = small_blind
         self.big_blind = big_blind
         self._poker_engine = PokerEngine(

--- a/pluribus/games/short_deck/state.py
+++ b/pluribus/games/short_deck/state.py
@@ -68,7 +68,6 @@ class ShortDeckPokerState:
         self._table.dealer.deal_private_cards(self._table.players)
         # Store the actions as they come in here.
         self._history: List[str] = []
-        self._player_i_index = 0
         self._betting_stage = "pre_flop"
         self._betting_stage_to_round: Dict[str, int] = {
             "pre_flop": 0,
@@ -122,6 +121,9 @@ class ShortDeckPokerState:
         new_state.info_set_lut = self.info_set_lut = lut
         if action_str is None:
             # Assert active player has folded already.
+            import ipdb
+
+            ipdb.set_trace()
             assert (
                 not new_state.current_player.is_active
             ), "Active player cannot do nothing!"
@@ -132,7 +134,7 @@ class ShortDeckPokerState:
             action = new_state.current_player.fold()
         elif action_str == "raise":
             bet_n_chips = new_state.big_blind
-            if self._betting_stage in {"turn", "river"}:
+            if new_state._betting_stage in {"turn", "river"}:
                 bet_n_chips *= 2
             biggest_bet = max(p.n_bet_chips for p in new_state.players)
             n_chips_to_call = biggest_bet - new_state.current_player.n_bet_chips
@@ -147,11 +149,29 @@ class ShortDeckPokerState:
             )
         # Update the new state.
         new_state._history.append(str(action))
+        new_state._n_actions += 1
         # Player has made move, increment the player that is next.
         while True:
             new_state._move_to_next_player()
-            terminal = self._betting_stage in {"terminal", "show_down"}
-            if new_state.current_player.is_active or terminal:
+            if new_state.current_player.is_active:
+                # If we have finished betting, (i.e: All players have put the
+                # same amount of chips in), then increment the stage of
+                # betting.
+                finished_betting = not new_state._poker_engine.more_betting_needed
+                if finished_betting and new_state.all_players_have_actioned:
+                    # We have done atleast one full round of betting, increment
+                    # stage of the game.
+                    new_state._increment_stage()
+                    new_state._reset_betting_round_state()
+                if new_state._poker_engine.n_players_with_moves == 1:
+                    # No players left.
+                    new_state._betting_stage = "terminal"
+                    if not new_state._table.community_cards:
+                        new_state._poker_engine.table.dealer.deal_flop(new_state._table)
+                # Now check if the game is terminal.
+                if new_state._betting_stage in {"terminal", "show_down"}:
+                    # Distribute winnings.
+                    new_state._poker_engine.compute_winners()
                 break
             else:
                 # The current player isn't active, and we are not terminal.
@@ -160,30 +180,14 @@ class ShortDeckPokerState:
                 # signify the notation h · 0 in algorithm 1 of the
                 # supplementary material of the Pluribus paper.
                 new_state._history.append("skip")
+            assert not new_state.current_player.is_active
         return new_state
 
     def _move_to_next_player(self):
-        """Ensure state points to next valid active player.
-
-        Setup game and assocaited game-state for the current turn.
-        """
+        """Ensure state points to next valid active player."""
         self._player_i_index += 1
         if self._player_i_index >= len(self.players):
             self._player_i_index = 0
-            finished_betting = not self._poker_engine.more_betting_needed
-            if finished_betting:
-                # We have done atleast one full round of betting, increment
-                # stage of the game.
-                self._increment_stage()
-        if self._poker_engine.n_players_with_moves == 1:
-            # No players left.
-            self._betting_stage = "terminal"
-            if not self._table.community_cards:
-                self._poker_engine.table.dealer.deal_flop(self._table)
-        # Now check if the game is terminal.
-        if self._betting_stage in {"terminal", "show_down"}:
-            # Distribute winnings.
-            self._poker_engine.compute_winners()
 
     def _load_pickle_files(
         self, pickle_dir: str
@@ -211,12 +215,14 @@ class ShortDeckPokerState:
     def _reset_betting_round_state(self):
         """Reset the state related to counting types of actions."""
         self._all_players_have_made_action = False
+        self._n_actions = 0
         self._n_raises = 0
+        self._player_i_index = 0
+        while not self.current_player.is_active:
+            self._player_i_index += 1
 
     def _increment_stage(self):
         """Once betting has finished, increment the stage of the poker game."""
-        # All players must bet.
-        self._reset_betting_round_state()
         # Progress the stage of the game.
         if self._betting_stage == "pre_flop":
             # Progress from private cards to the flop.
@@ -233,10 +239,15 @@ class ShortDeckPokerState:
         elif self._betting_stage == "river":
             # Progress to the showdown.
             self._betting_stage = "show_down"
-        elif self._betting_stage == "terminal":
+        elif self._betting_stage in {"show_down", "terminal"}:
             pass
         else:
             raise ValueError(f"Unknown betting_stage: {self._betting_stage}")
+
+    @property
+    def all_players_have_actioned(self):
+        """Return whether all players have made atleast one action."""
+        return self._n_actions >= self._poker_engine.n_active_players
 
     @property
     def player_i(self) -> int:
@@ -275,7 +286,15 @@ class ShortDeckPokerState:
             reverse=True,
         )
         eval_cards = tuple([card.eval_card for card in cards])
-        cards_cluster = self.info_set_lut[self._betting_stage][eval_cards]
+        try:
+            cards_cluster = self.info_set_lut[self._betting_stage][eval_cards]
+        except KeyError:
+            if not self.info_set_lut:
+                raise ValueError("Pickle luts must be loaded for info set.")
+            elif eval_cards not in self.info_set_lut[self._betting_stage]:
+                raise ValueError("Cards {cards} not in pickle files.")
+            else:
+                raise ValueError("Unrecognised betting stage in pickle files.")
         action_history = [str(action) for action in self._history]
         return f"cards_cluster={cards_cluster}, history={action_history}"
 

--- a/pluribus/games/short_deck/state.py
+++ b/pluribus/games/short_deck/state.py
@@ -121,9 +121,6 @@ class ShortDeckPokerState:
         new_state.info_set_lut = self.info_set_lut = lut
         if action_str is None:
             # Assert active player has folded already.
-            import ipdb
-
-            ipdb.set_trace()
             assert (
                 not new_state.current_player.is_active
             ), "Active player cannot do nothing!"
@@ -245,7 +242,12 @@ class ShortDeckPokerState:
             raise ValueError(f"Unknown betting_stage: {self._betting_stage}")
 
     @property
-    def all_players_have_actioned(self):
+    def betting_stage(self) -> str:
+        """Return betting stage."""
+        return self._betting_stage
+
+    @property
+    def all_players_have_actioned(self) -> bool:
         """Return whether all players have made atleast one action."""
         return self._n_actions >= self._poker_engine.n_active_players
 

--- a/pluribus/poker/dealer.py
+++ b/pluribus/poker/dealer.py
@@ -7,41 +7,50 @@ from pluribus.poker.deck import Deck
 if TYPE_CHECKING:
     from pluribus.poker.table import PokerTable
     from pluribus.poker.player import Player
+    from pluribus.poker.card import Card
 
 
 class Dealer:
     """The dealer is in charge of handling the cards on a poker table."""
 
-    def __init__(self):
-        self.deck = Deck()
-        self.deck.shuffle()
+    def __init__(self, **deck_kwargs):
+        self.deck = Deck(**deck_kwargs)
 
-    def deal_card(self):
-        return self.deck.pick()
-
-    def use_fresh_deck(self):
-        self.deck = Deck()
-        self.deck.shuffle()
+    def deal_card(self) -> Card:
+        """Return a completely random card."""
+        return self.deck.pick(random=True)
 
     def deal_private_cards(self, players: List[Player]):
+        """Deal private card to players.
+
+        Parameters
+        ----------
+        players : list of Player
+            The players to deal the private cards to.
+        """
         for _ in range(2):
             for player in players:
-                card = self.deal_card()
+                card: Card = self.deal_card()
                 player.add_private_card(card)
 
-    def deal_community_cards(self, table: PokerTable, num_cards: int):
-        assert num_cards > 0
-        # TODO(fedden): Do we need to burn a card like in casinos? Check the
-        #               papers supplimentary materials.
-        for _ in range(num_cards):
-            card = self.deal_card()
+    def deal_community_cards(self, table: PokerTable, n_cards: int):
+        """Deal public cards."""
+        if n_cards <= 0:
+            raise ValueError(
+                f"Positive n of cards must be specified, but got {n_cards}"
+            )
+        for _ in range(n_cards):
+            card: Card = self.deal_card()
             table.add_community_card(card)
 
     def deal_flop(self, table: PokerTable):
+        """Deal the flop public cards to the `table`."""
         return self.deal_community_cards(table, 3)
 
     def deal_turn(self, table: PokerTable):
+        """Deal the turn public cards to the `table`."""
         return self.deal_community_cards(table, 1)
 
     def deal_river(self, table: PokerTable):
+        """Deal the river public cards to the `table`."""
         return self.deal_community_cards(table, 1)

--- a/pluribus/poker/deck.py
+++ b/pluribus/poker/deck.py
@@ -17,7 +17,7 @@ class Deck:
     def __init__(
         self,
         include_suits: List[str] = default_include_suits,
-        include_ranks: List[str] = default_include_ranks,
+        include_ranks: List[int] = default_include_ranks,
     ):
         """Construct the deck of cards."""
         self._include_suits = include_suits

--- a/pluribus/poker/deck.py
+++ b/pluribus/poker/deck.py
@@ -1,28 +1,63 @@
 from __future__ import annotations
 
 import random
+from typing import List
+
+import numpy as np
 
 from pluribus.poker.card import Card, get_all_suits
 
+default_include_suits: List[str] = list(get_all_suits())
+default_include_ranks: List[int] = list(range(2, 15))
+
 
 class Deck:
-    def __init__(self):
-        self._cards = [
+    """Class to manage the deck."""
+
+    def __init__(
+        self,
+        include_suits: List[str] = default_include_suits,
+        include_ranks: List[str] = default_include_ranks,
+    ):
+        """Construct the deck of cards."""
+        self._include_suits = include_suits
+        self._include_ranks = include_ranks
+        self.reset()
+
+    def __len__(self) -> int:
+        """Return overall length of the deck."""
+        return len(self._cards_in_deck) + len(self._dealt_cards)
+
+    def reset(self):
+        """Reset the deck and shuffle it, ready for use."""
+        self._cards_in_deck: List[Card] = [
             Card(rank, suit)
-            for suit in get_all_suits() for rank in range(2, 15)
+            for suit in self._include_suits
+            for rank in self._include_ranks
         ]
+        self._dealt_cards: List[Card] = []
+        random.shuffle(self._cards_in_deck)
 
-    def __len__(self):
-        return len(self._cards)
+    def pick(self, random: bool = True) -> Card:
+        """Return a card from the deck.
 
-    def __getitem__(self, position):
-        return self._cards[position]
+        Parameters
+        ----------
+        random : bool
+            If this is true, return a completely random card, else return the
+            next card in the deck.
 
-    def __setitem__(self, position, card):
-        self._cards[position] = card
-
-    def shuffle(self):
-        random.shuffle(self._cards)
-
-    def pick(self):
-        return self._cards.pop()
+        Returns
+        -------
+        card : Card
+            The card that was picked.
+        """
+        if not len(self._cards_in_deck):
+            raise ValueError("Deck is empty - please use Deck.reset()")
+        elif random:
+            index: int = np.random.randint(len(self._cards_in_deck), size=None)
+        else:
+            index: int = len(self._cards_in_deck) - 1
+        card: Card = self._cards_in_deck.pop(index)
+        self._dealt_cards.append(card)
+        return card

--- a/pluribus/poker/table.py
+++ b/pluribus/poker/table.py
@@ -17,21 +17,21 @@ class PokerTable:
     Each player is responisble for handling his own cards privately.
     """
 
-    def __init__(self, players: List[Player], pot: Pot):
+    def __init__(self, players: List[Player], pot: Pot, **deck_kwargs):
         """Construct the table."""
-        self.players = players
-        self.total_n_chips_on_table = sum(p.n_chips for p in self.players)
-        self.pot = pot
-        self.dealer = Dealer()
+        self.players: List[Player] = players
+        self.total_n_chips_on_table: int = sum(p.n_chips for p in self.players)
+        self.pot: Pot = pot
+        self.dealer: Dealer = Dealer(**deck_kwargs)
         self.community_cards: List[Card] = []
-        self.n_games = 0
+        self.n_games: int = 0
         if self.n_players < 2:
             raise ValueError(f'Must be atleast two players on the table.')
         if not all(p.pot.uid == self.pot.uid for p in self.players):
             raise ValueError(f'Players and table point to different pots.')
 
     @property
-    def n_players(self):
+    def n_players(self) -> int:
         """How many players are on the table?"""
         return len(self.players)
 

--- a/test/functional/test_short_deck.py
+++ b/test/functional/test_short_deck.py
@@ -1,20 +1,39 @@
+from typing import Tuple, Union
+
 import pytest
 import numpy as np
+
+from pluribus.games.short_deck.state import ShortDeckPokerState
+from pluribus.games.short_deck.player import ShortDeckPokerPlayer
+from pluribus.poker.pot import Pot
+from pluribus.utils.random import seed
+
+
+def _new_game(
+    n_players: int,
+    small_blind: int = 50,
+    big_blind: int = 100,
+    initial_chips: int = 10000,
+) -> Tuple[ShortDeckPokerState, Pot]:
+    """Create a new game."""
+    pot = Pot()
+    players = [
+        ShortDeckPokerPlayer(player_i=player_i, pot=pot, initial_chips=initial_chips)
+        for player_i in range(n_players)
+    ]
+    state = ShortDeckPokerState(
+        players=players,
+        load_pickle_files=False,
+        small_blind=small_blind,
+        big_blind=big_blind,
+    )
+    return state, pot
 
 
 def test_short_deck_1():
     """Test the short deck poker game state works as expected."""
-    from pluribus.games.short_deck.player import ShortDeckPokerPlayer
-    from pluribus.games.short_deck.state import ShortDeckPokerState
-    from pluribus.poker.pot import Pot
-
     n_players = 3
-    pot = Pot()
-    players = [
-        ShortDeckPokerPlayer(player_i=player_i, pot=pot, initial_chips=10000)
-        for player_i in range(n_players)
-    ]
-    state = ShortDeckPokerState(players=players, load_pickle_files=False)
+    state, _ = _new_game(n_players=n_players)
     # Call for all players.
     player_i_order = [2, 0, 1]
     for i in range(n_players):
@@ -22,6 +41,7 @@ def test_short_deck_1():
         assert len(state.legal_actions) == 3
         assert state._betting_stage == "pre_flop"
         state = state.apply_action(action_str="call")
+    assert state._betting_stage == "flop"
     # Fold for all but last player.
     for player_i in range(n_players - 1):
         assert state.current_player.name == f"player_{player_i}"
@@ -35,17 +55,8 @@ def test_short_deck_1():
 
 def test_short_deck_2():
     """Test the short deck poker game state works as expected."""
-    from pluribus.games.short_deck.player import ShortDeckPokerPlayer
-    from pluribus.games.short_deck.state import ShortDeckPokerState
-    from pluribus.poker.pot import Pot
-
     n_players = 3
-    pot = Pot()
-    players = [
-        ShortDeckPokerPlayer(player_i=player_i, pot=pot, initial_chips=10000)
-        for player_i in range(n_players)
-    ]
-    state = ShortDeckPokerState(players=players, load_pickle_files=False)
+    state, _ = _new_game(n_players=3)
     player_i_order = [2, 0, 1]
     # Call for all players.
     for i in range(n_players):
@@ -60,7 +71,7 @@ def test_short_deck_2():
         assert state._betting_stage == "flop"
         state = state.apply_action(action_str="raise")
     # Call for all players and ensure all players have chipped in the same..
-    for player_i in range(n_players):
+    for player_i in range(n_players - 1):
         assert state.current_player.name == f"player_{player_i}"
         assert len(state.legal_actions) == 2
         assert state._betting_stage == "flop"
@@ -72,7 +83,7 @@ def test_short_deck_2():
         assert state._betting_stage == "turn"
         state = state.apply_action(action_str="raise")
     # Call for all players and ensure all players have chipped in the same..
-    for player_i in range(n_players):
+    for player_i in range(n_players - 1):
         assert state.current_player.name == f"player_{player_i}"
         assert len(state.legal_actions) == 2
         assert state._betting_stage == "turn"
@@ -105,16 +116,7 @@ def test_short_deck_3(n_players: int):
     order of the players is correct - for the pre-flop it should be
     [-1, -2, 0, 1, ..., -3].
     """
-    from pluribus.games.short_deck.player import ShortDeckPokerPlayer
-    from pluribus.games.short_deck.state import ShortDeckPokerState
-    from pluribus.poker.pot import Pot
-
-    pot = Pot()
-    players = [
-        ShortDeckPokerPlayer(player_i=player_i, pot=pot, initial_chips=10000)
-        for player_i in range(n_players)
-    ]
-    state = ShortDeckPokerState(players=players, load_pickle_files=False)
+    state, _ = _new_game(n_players=n_players)
     order = list(range(n_players))
     player_i_order = {
         "pre_flop": order[2:] + order[:2],
@@ -146,20 +148,8 @@ def test_short_deck_3(n_players: int):
 @pytest.mark.parametrize("big_blind", [100, 1000])
 def test_pre_flop_pot(n_players: int, small_blind: int, big_blind: int):
     """Test preflop the state is set up for player 2 to start betting."""
-    from pluribus.games.short_deck.player import ShortDeckPokerPlayer
-    from pluribus.games.short_deck.state import ShortDeckPokerState
-    from pluribus.poker.pot import Pot
-
-    pot = Pot()
-    players = [
-        ShortDeckPokerPlayer(player_i=player_i, pot=pot, initial_chips=10000)
-        for player_i in range(n_players)
-    ]
-    state = ShortDeckPokerState(
-        players=players,
-        load_pickle_files=False,
-        small_blind=small_blind,
-        big_blind=big_blind,
+    state, pot = _new_game(
+        n_players=n_players, small_blind=small_blind, big_blind=big_blind,
     )
     n_bet_chips = sum(p.n_bet_chips for p in state.players)
     target = small_blind + big_blind
@@ -173,50 +163,35 @@ def test_pre_flop_pot(n_players: int, small_blind: int, big_blind: int):
     ), f"small and big blind have are not in pot! {n_bet_chips} == {pot.total}"
 
 
-def _play_game_helper(state, betting_round_dict, bad_seq):
-    p = 1 / len(state.legal_actions)
-    probabilities = np.full(len(state.legal_actions), p)
-    a = np.random.choice(state.legal_actions, p=probabilities)
-    betting_stage = state._betting_stage
-    if betting_stage not in ["show_down", "terminal"]:
-        if state._poker_engine.n_active_players == 2:
-            betting_round_dict[betting_stage].append(a)
-            lst = [x for x in betting_round_dict[betting_stage] if x != "skip"]
-            for i in range(len(lst)):
-                assert lst[i : i + len(bad_seq)] != bad_seq
-        state = state.apply_action(a)
-
-        _play_game_helper(state, betting_round_dict, bad_seq)
-
-
-@pytest.mark.parametrize("n_players", [2, 3])
-@pytest.mark.parametrize("small_blind", [50])
-@pytest.mark.parametrize("big_blind", [100])
-def test_call_action_sequence(n_players: int, small_blind: int, big_blind: int):
+def test_call_action_sequence():
     """
     Make sure we never see an action sequence of "raise", "call", "call" in the same
     round with only two players. There would be a similar analog for more than two players,
     but this should aid in initially finding the bug.
     """
-    from pluribus.games.short_deck.player import ShortDeckPokerPlayer
-    from pluribus.games.short_deck.state import ShortDeckPokerState
-    from pluribus.poker.pot import Pot
-
-    pot = Pot()
-    players = [
-        ShortDeckPokerPlayer(player_i=player_i, pot=pot, initial_chips=10000)
-        for player_i in range(n_players)
-    ]
-
-    state = ShortDeckPokerState(
-        players=players,
-        load_pickle_files=False,
-        small_blind=small_blind,
-        big_blind=big_blind,
-    )
-
+    seed(42)
     # example of a bad sequence in a two-handed game in one round
     bad_seq = ["raise", "call", "call"]
     for t in range(100):
+        state, _ = _new_game(n_players=3, small_blind=50, big_blind=100)
         betting_round_dict = {"pre_flop": [], "flop": [], "turn": [], "river": []}
-        _play_game_helper(state, betting_round_dict, bad_seq)
+        iteration_i = 0
+        while state._betting_stage not in {"show_down", "terminal"}:
+            uniform_probability = 1 / len(state.legal_actions)
+            probabilities = np.full(len(state.legal_actions), uniform_probability)
+            random_action = np.random.choice(state.legal_actions, p=probabilities)
+            betting_stage = state._betting_stage
+            if state._poker_engine.n_active_players == 2:
+                betting_round_dict[betting_stage].append(random_action)
+                no_fold_action_history = [
+                    action
+                    for action in betting_round_dict[betting_stage]
+                    if action != "skip"
+                ]
+                # Loop through the action history and make sure the bad
+                # sequence has not happened.
+                for i in range(len(no_fold_action_history)):
+                    history_slice = no_fold_action_history[i : i + len(bad_seq)]
+                    assert history_slice != bad_seq
+            state = state.apply_action(random_action)
+            iteration_i += 1

--- a/test/functional/test_short_deck.py
+++ b/test/functional/test_short_deck.py
@@ -163,7 +163,8 @@ def test_pre_flop_pot(n_players: int, small_blind: int, big_blind: int):
     ), f"small and big blind have are not in pot! {n_bet_chips} == {pot.total}"
 
 
-def test_call_action_sequence():
+@pytest.mark.parametrize("n_players", [2, 3])
+def test_call_action_sequence(n_players):
     """
     Make sure we never see an action sequence of "raise", "call", "call" in the same
     round with only two players. There would be a similar analog for more than two players,
@@ -172,10 +173,9 @@ def test_call_action_sequence():
     seed(42)
     # example of a bad sequence in a two-handed game in one round
     bad_seq = ["raise", "call", "call"]
-    for t in range(100):
-        state, _ = _new_game(n_players=3, small_blind=50, big_blind=100)
+    for _ in range(1000):
+        state, _ = _new_game(n_players=n_players, small_blind=50, big_blind=100)
         betting_round_dict = {"pre_flop": [], "flop": [], "turn": [], "river": []}
-        iteration_i = 0
         while state._betting_stage not in {"show_down", "terminal"}:
             uniform_probability = 1 / len(state.legal_actions)
             probabilities = np.full(len(state.legal_actions), uniform_probability)
@@ -194,4 +194,3 @@ def test_call_action_sequence():
                     history_slice = no_fold_action_history[i : i + len(bad_seq)]
                     assert history_slice != bad_seq
             state = state.apply_action(random_action)
-            iteration_i += 1

--- a/test/functional/test_short_deck.py
+++ b/test/functional/test_short_deck.py
@@ -173,7 +173,7 @@ def test_call_action_sequence(n_players):
     seed(42)
     # example of a bad sequence in a two-handed game in one round
     bad_seq = ["raise", "call", "call"]
-    for _ in range(1000):
+    for _ in range(200):
         state, _ = _new_game(n_players=n_players, small_blind=50, big_blind=100)
         betting_round_dict = {"pre_flop": [], "flop": [], "turn": [], "river": []}
         while state._betting_stage not in {"show_down", "terminal"}:


### PR DESCRIPTION
Fixes:
* Fixing the state class to remove action sequences of: ["raise", "call", "call"] when 2 players
* Fixing the deck to deal completely random cards, not one by one from a once-only shuffled deck

I also edited Colin's og failing test, purely to make it not recursive (way easier to add a debugger for a specific iteration where it was failing)

Adds test to ensure that flops are different on different iterations of the same state: https://github.com/fedden/poker_ai/blob/5b3f8ea5018a5b98459db6680a39776a2bee7693/test/functional/test_short_deck.py#L170-L192