### PR TITLE
Add --debug_quick_start as arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ python -m pluribus.terminal.runner       \
   --agent offline                        \ 
   --pickle_dir ./research/blueprint_algo \
   --strategy_path ./research/blueprint_algo/offline_strategy_285800.gz 
+  --debug_quick_start
 ```
 
 ### Web visualisation code

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ cd /path/to/pluribus/dir
 python -m pluribus.terminal.runner       \
   --agent offline                        \ 
   --pickle_dir ./research/blueprint_algo \
-  --strategy_path ./research/blueprint_algo/offline_strategy_285800.gz 
+  --strategy_path ./research/blueprint_algo/offline_strategy_285800.gz \
   --debug_quick_start
 ```
 


### PR DESCRIPTION
Couldn't get the terminal visualisation to work, but noticed that in the `asciinema` there was an argument that was not in the readme. I added it and it works perfectly.